### PR TITLE
fix: serve fresh must-revalidate entries without revalidation

### DIFF
--- a/.changeset/fix-must-revalidate-fresh-entries.md
+++ b/.changeset/fix-must-revalidate-fresh-entries.md
@@ -1,0 +1,5 @@
+---
+"@web-widget/http-cache-semantics": patch
+---
+
+Fix `evaluateRequest()` and `satisfiesWithoutRevalidation()` incorrectly forcing revalidation for fresh entries with `Cache-Control: must-revalidate`. Per RFC 9111 §5.2.2.2, `must-revalidate` only restricts reuse of stale entries; fresh responses may be served without contacting the origin.

--- a/src/index.ts
+++ b/src/index.ts
@@ -347,11 +347,6 @@ export default class CachePolicy {
   evaluateRequest(req: Request): EvaluateRequestResult {
     this.#assertRequestHasHeaders(req);
 
-    // In all circumstances, a cache MUST NOT ignore the must-revalidate directive
-    if (this.#resCacheControl['must-revalidate']) {
-      return this.#evaluateRequestMissResult(req);
-    }
-
     if (!this.#requestMatches(req, false)) {
       return this.#evaluateRequestMissResult(req);
     }
@@ -388,6 +383,7 @@ export default class CachePolicy {
     if (this.stale()) {
       const allowsStaleWithoutRevalidation =
         'max-stale' in reqCacheControl &&
+        !this.#resCacheControl['must-revalidate'] &&
         (true === reqCacheControl['max-stale'] ||
           Number(reqCacheControl['max-stale']) > this.age() - this.maxAge());
 

--- a/test/okhttp.test.ts
+++ b/test/okhttp.test.ts
@@ -436,6 +436,41 @@ describe('okhttp tests', () => {
     ).toBeFalsy();
   });
 
+  test('fresh must-revalidate may be served without revalidation', () => {
+    const cache = new CachePolicy(
+      new Request('http://localhost/'),
+      new Response(null, {
+        headers: { 'cache-control': 'max-age=300, must-revalidate' },
+      })
+    );
+
+    expect(cache.stale()).toBe(false);
+    expect(
+      cache.satisfiesWithoutRevalidation(new Request('http://localhost/'))
+    ).toBe(true);
+
+    const result = cache.evaluateRequest(new Request('http://localhost/'));
+    expect(result.revalidation).toBeUndefined();
+    expect(result.response).toBeDefined();
+  });
+
+  test('stale must-revalidate requires revalidation', () => {
+    const cache = new CachePolicy(
+      new Request('http://localhost/'),
+      new Response(null, {
+        headers: {
+          'cache-control': 'max-age=120, must-revalidate',
+          age: '360',
+        },
+      })
+    );
+
+    expect(cache.stale()).toBe(true);
+    const result = cache.evaluateRequest(new Request('http://localhost/'));
+    expect(result.revalidation?.synchronous).toBe(true);
+    expect(result.response).toBeUndefined();
+  });
+
   test('request max stale not honored with must revalidate', () => {
     const cache = new CachePolicy(
       new Request('http://localhost/'),


### PR DESCRIPTION
## Summary

- Remove the unconditional `must-revalidate` early return in `evaluateRequest()` that forced synchronous revalidation even for fresh cache entries
- Restore `!must-revalidate` guard in the stale branch when evaluating client `max-stale`
- Add test coverage for fresh and stale `must-revalidate` scenarios
- Add changeset for patch release (2.0.1)

Per [RFC 9111 §5.2.2.2](https://www.rfc-editor.org/rfc/rfc9111#section-5.2.2.2), `must-revalidate` only restricts reuse of **stale** entries. Fresh responses may be served without contacting the origin.

This fixes a regression introduced when merging upstream kornelski/http-cache-semantics v4.2.0 (commit `184f54b`). The same fix has been submitted upstream: [kornelski/http-cache-semantics#54](https://github.com/kornelski/http-cache-semantics/pull/54).

## Test plan

- [x] `npm test` — 119 tests passing
- [x] `fresh must-revalidate may be served without revalidation`
- [x] `stale must-revalidate requires revalidation`
- [x] Existing `request max stale not honored with must revalidate` still passes